### PR TITLE
日志打印优化,将请求中的token作为用户标识

### DIFF
--- a/pkg/azure/proxy.go
+++ b/pkg/azure/proxy.go
@@ -76,11 +76,12 @@ func NewOpenAIReverseProxy() *httputil.ReverseProxy {
 		// Replace the Bearer field in the Authorization header with api-key
 		token := ""
 
+		tokenFromReq := strings.ReplaceAll(req.Header.Get("Authorization"), "Bearer ", "")
 		// use the token from the environment variable if it is set
 		if AzureOpenAIToken != "" {
 			token = AzureOpenAIToken
 		} else {
-			token = strings.ReplaceAll(req.Header.Get("Authorization"), "Bearer ", "")
+			token = tokenFromReq
 		}
 
 		req.Header.Set("api-key", token)
@@ -99,7 +100,8 @@ func NewOpenAIReverseProxy() *httputil.ReverseProxy {
 		query.Add("api-version", AzureOpenAIAPIVersion)
 		req.URL.RawQuery = query.Encode()
 
-		log.Printf("proxying request [%s] %s -> %s", model, originURL, req.URL.String())
+		log.Printf("user identity: [%s], proxying request [%s] %s -> %s",
+			tokenFromReq, model, originURL, req.URL.String())
 	}
 	return &httputil.ReverseProxy{Director: director}
 }


### PR DESCRIPTION
1. 将日志输出到文件及stdout中，日志路径默认log/proxy.log，可使用AZURE_OPENAI_PROXY_LOG_PATH定制
2. 在azure proxy日志打印中，增加原始请求中token打印。原因是：你可以将一个openai token提供给组织其他人使用，并通过请求中的token进行标识，方便后续统计组织内人员使用次数。